### PR TITLE
ITG-3: As an Admin, I can manage products and categories (CRUD)

### DIFF
--- a/app/controllers/category_controller.go
+++ b/app/controllers/category_controller.go
@@ -1,0 +1,277 @@
+package controllers
+
+import (
+	"errors"
+	"log"
+	"monitoring-service/app/helpers"
+	"monitoring-service/app/models"
+	"net/http"
+	"strconv"
+
+	"github.com/ezartsh/validet"
+	"github.com/labstack/echo/v4"
+	"gorm.io/gorm"
+
+	customerror "monitoring-service/pkg/customerror"
+)
+
+type categoryController controller
+
+type CategoryControllerInterface interface {
+	GetCategoryByID(c echo.Context) error
+	GetAllCategory(c echo.Context) error
+	CreateCategory(c echo.Context) error
+	UpdateCategory(c echo.Context) error
+	SoftDeleteCategory(c echo.Context) error
+}
+
+func (ctrl *categoryController) GetCategoryByID(c echo.Context) error {
+	var (
+		req      *models.CategoryAdmin
+		category *models.CategoryResponses
+		err      error
+		id       string
+	)
+
+	id = c.Param("id")
+
+	mapReq := make(map[string]any)
+	mapReq["id"] = id
+
+	schema := validet.NewSchema(
+		mapReq,
+		map[string]validet.Rule{
+			"id": validet.String{Required: true, Custom: func(v string, path validet.PathKey, lookup validet.Lookup) error {
+				if _, err := strconv.Atoi(v); err != nil {
+					return customerror.NewBadRequestError("Invalid category ID format")
+				}
+				return nil
+			}},
+		},
+		validet.Options{},
+	)
+
+	errorBags, err := schema.Validate()
+	if err != nil {
+		err := customerror.NewBadRequestError(err.Error())
+		return helpers.StandardResponse(c, customerror.GetStatusCode(err), errorBags.Errors, nil, nil)
+	}
+
+	categoryID, _ := strconv.Atoi(id)
+
+	if err := c.Bind(&req); err != nil {
+		return helpers.Response(c, http.StatusBadRequest, []string{"Invalid request"})
+	}
+
+	log.Printf("Fetching category with Include related: %t", req.IncludeRelated)
+	category, err = ctrl.Options.UseCases.Category.GetCategoryByID(categoryID, req.IncludeRelated)
+	if err != nil {
+
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			err = customerror.NewNotFoundError("Category not found")
+		}
+
+		var nfErr customerror.NotFoundError
+		if errors.As(err, &nfErr) {
+			return helpers.Response(c, http.StatusNotFound, []string{"Category not found"})
+		}
+
+		return helpers.Response(c, customerror.GetStatusCode(err), []string{err.Error()})
+	}
+
+	return helpers.StandardResponse(c, http.StatusOK, []string{"Caregory retrieved successfully"}, category, nil)
+}
+
+func (ctrl *categoryController) GetAllCategory(c echo.Context) error {
+	page, err := strconv.Atoi(c.QueryParam("page"))
+	if err != nil || page < 1 {
+		page = 1
+	}
+
+	pageSize, _ := strconv.Atoi(c.QueryParam("page_size"))
+	if pageSize <= 0 {
+		pageSize = 10
+	}
+
+	q := c.QueryParam("q")
+	includeDeleted := false
+	if c.QueryParam("include_deleted") == "true" {
+		includeDeleted = true
+	}
+
+	mapParams := map[string]any{
+		"page":            page,
+		"page_size":       pageSize,
+		"q":               q,
+		"include_deleted": includeDeleted,
+	}
+	schema := validet.NewSchema(
+		mapParams,
+		map[string]validet.Rule{
+			"page": validet.Numeric[int]{Required: false, Custom: func(v int, path validet.PathKey, lookup validet.Lookup) error {
+				if v != 0 && v < 1 {
+					return customerror.NewBadRequestError("Page must be minimum of 1")
+				}
+				return nil
+			}},
+			"page_size": validet.Numeric[int]{Required: false, Custom: func(v int, path validet.PathKey, lookup validet.Lookup) error {
+				if v != 0 && v < 1 {
+					return customerror.NewBadRequestError("page_size must be minimum of 1 or maximum 100")
+				}
+				return nil
+			}},
+			"q":               validet.String{Required: false, Max: 100},
+			"include_deleted": validet.Boolean{Required: false},
+		},
+		validet.Options{},
+	)
+
+	errorBags, err := schema.Validate()
+	if err != nil {
+		return helpers.StandardResponse(c, http.StatusBadRequest, errorBags.Errors, nil, nil)
+	}
+
+	category, total, err := ctrl.Options.UseCases.Category.GetAllCategory(page, pageSize, q, includeDeleted)
+	if err != nil {
+		return helpers.Response(c, http.StatusInternalServerError, []string{err.Error()})
+	}
+
+	if len(*category) == 0 {
+		return helpers.Response(c, http.StatusNotFound, []string{"No categories found"})
+	}
+	return helpers.StandardResponse(c, http.StatusOK, []string{"Categories fetched successfully"}, map[string]interface{}{
+		"page":     page,
+		"pageSize": pageSize,
+		"total":    total,
+		"category": category,
+	}, nil)
+}
+
+func (ctrl *categoryController) CreateCategory(c echo.Context) error {
+	var (
+		req models.Category
+		//		name string
+		description string
+	)
+	if err := c.Bind(&req); err != nil {
+		return helpers.Response(c, http.StatusBadRequest, []string{"Invalid request"})
+	}
+
+	if req.Description != nil {
+		description = *req.Description
+	}
+
+	mapReq := map[string]any{
+		"name":        req.Name,
+		"description": description,
+	}
+
+	schema := validet.NewSchema(
+		mapReq,
+		map[string]validet.Rule{
+			"name":        validet.String{Required: true, Min: 1, Max: 100},
+			"description": validet.String{Required: false, Max: 500},
+		},
+		validet.Options{},
+	)
+
+	errorBags, err := schema.Validate()
+	if err != nil {
+		return helpers.StandardResponse(c, http.StatusBadRequest, errorBags.Errors, nil, nil)
+	}
+
+	newCategory, err := ctrl.Options.UseCases.Category.CreateCategory(&req)
+	if err != nil {
+		return helpers.Response(c, http.StatusInternalServerError, []string{err.Error()})
+	}
+	return helpers.StandardResponse(c, http.StatusCreated, []string{"Category created successfully"}, newCategory, nil)
+}
+
+func (ctrl *categoryController) UpdateCategory(c echo.Context) error {
+	var req models.Category
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		return helpers.Response(c, http.StatusBadRequest, []string{"Invalid category ID"})
+	}
+
+	if id != 0 && id < 1 {
+		return helpers.Response(c, http.StatusBadRequest, []string{"Category ID must be greater than 0"})
+	}
+
+	if err := c.Bind(&req); err != nil {
+		return helpers.Response(c, http.StatusBadRequest, []string{"Invalid update request"})
+	}
+
+	mapReq := map[string]any{}
+	if req.Name != "" {
+		mapReq["name"] = req.Name
+	}
+	if req.Description != nil {
+		mapReq["description"] = *req.Description
+	}
+
+	if len(mapReq) == 0 {
+		return helpers.Response(c, http.StatusBadRequest, []string{"No fields to update"})
+	}
+
+	schema := validet.NewSchema(
+		mapReq,
+		map[string]validet.Rule{
+			"name":        validet.String{Required: false, Max: 100},
+			"description": validet.String{Required: false, Max: 500},
+		},
+		validet.Options{},
+	)
+
+	errorBags, err := schema.Validate()
+
+	if err != nil {
+		return helpers.StandardResponse(c, http.StatusBadRequest, errorBags.Errors, nil, nil)
+	}
+
+	category, err := ctrl.Options.UseCases.Category.UpdateCategory(id, mapReq)
+
+	if err != nil {
+		return helpers.Response(c, http.StatusInternalServerError, []string{err.Error()})
+	}
+	return helpers.StandardResponse(c, http.StatusOK, []string{"Category updated successfully"}, category, nil)
+}
+
+func (ctrl *categoryController) SoftDeleteCategory(c echo.Context) error {
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		return helpers.Response(c, http.StatusBadRequest, []string{"Invalid or empty category ID"})
+	}
+
+	mapReq := make(map[string]any)
+	if id != 0 && id > 0 {
+		mapReq["id"] = id
+	}
+
+	if len(mapReq) == 0 {
+		return helpers.Response(c, http.StatusBadRequest, []string{"Category ID is required"})
+	}
+
+	schema := validet.NewSchema(
+		mapReq,
+		map[string]validet.Rule{
+			"id": validet.Numeric[int]{Required: true, Custom: func(v int,
+				path validet.PathKey, lookup validet.Lookup) error {
+				if v != 0 && v < 1 {
+					return customerror.NewBadRequestError("Product ID must be greater than 0")
+				}
+				return nil
+			}},
+		},
+		validet.Options{},
+	)
+	errorBags, err := schema.Validate()
+	if err != nil {
+		return helpers.StandardResponse(c, http.StatusBadRequest, errorBags.Errors, nil, nil)
+	}
+
+	if err := ctrl.Options.UseCases.Category.SoftDeleteCategory(id); err != nil {
+		return helpers.Response(c, http.StatusInternalServerError, []string{err.Error()})
+	}
+	return helpers.StandardResponse(c, http.StatusOK, []string{"Category deleted successfully"}, nil, nil)
+}

--- a/app/controllers/init.go
+++ b/app/controllers/init.go
@@ -6,9 +6,10 @@ import (
 )
 
 type Main struct {
-	User    UserControllerInterface
-	Auth    AuthControllerInterface
-	Product productControllerInterface
+	User     UserControllerInterface
+	Auth     AuthControllerInterface
+	Product  productControllerInterface
+	Category CategoryControllerInterface
 }
 
 type controller struct {
@@ -24,9 +25,10 @@ func Init(opts Options) *Main {
 	ctrl := &controller{opts}
 
 	m := &Main{
-		User:    (*userController)(ctrl),
-		Auth:    (*authController)(ctrl),
-		Product: (*productController)(ctrl),
+		User:     (*userController)(ctrl),
+		Auth:     (*authController)(ctrl),
+		Product:  (*productController)(ctrl),
+		Category: (*categoryController)(ctrl),
 	}
 
 	return m

--- a/app/controllers/product_controller.go
+++ b/app/controllers/product_controller.go
@@ -18,6 +18,10 @@ type productController controller
 
 type productControllerInterface interface {
 	GetProductByID(c echo.Context) error
+	CreateProduct(c echo.Context) error
+	UpdateProduct(c echo.Context) error
+	SoftDeleteProduct(c echo.Context) error
+	GetAllProduct(c echo.Context) error
 }
 
 func (ctrl *productController) GetProductByID(c echo.Context) error {
@@ -76,4 +80,273 @@ func (ctrl *productController) GetProductByID(c echo.Context) error {
 	}
 
 	return helpers.StandardResponse(c, http.StatusOK, []string{"Product retrieved successfully"}, product, nil)
+}
+
+func (ctrl *productController) CreateProduct(c echo.Context) error {
+	var (
+		req         models.Product
+		description string
+		categoryID  int
+		imageURL    string
+	)
+	if err := c.Bind(&req); err != nil {
+		return helpers.Response(c, http.StatusBadRequest, []string{"Invalid request"})
+	}
+
+	if req.CategoryID != nil {
+		categoryID = *req.CategoryID
+	}
+
+	if req.Description != nil {
+		description = *req.Description
+	}
+
+	if req.ImageURL != nil {
+		imageURL = *req.ImageURL
+	}
+
+	mapReq := map[string]any{
+		"name":        req.Name,
+		"description": description,
+		"price":       req.Price,
+		"stock":       req.Stock,
+		"category_id": categoryID,
+		"image_url":   imageURL,
+	}
+
+	schema := validet.NewSchema(
+		mapReq,
+		map[string]validet.Rule{
+			"name":        validet.String{Required: true, Min: 1, Max: 100},
+			"description": validet.String{Required: false, Max: 500},
+			"price":       validet.Numeric[float64]{Required: true, Min: 1},
+			"stock":       validet.Numeric[int]{Required: true, Min: 1},
+			"category_id": validet.Numeric[int]{Required: true, Min: 1},
+			"image_url":   validet.String{Required: false, Max: 255},
+		},
+		validet.Options{},
+	)
+
+	errorBags, err := schema.Validate()
+	if err != nil {
+		return helpers.StandardResponse(c, http.StatusBadRequest, errorBags.Errors, nil, nil)
+	}
+
+	category, err := ctrl.Options.UseCases.Category.IsCategoryExist(categoryID)
+	if category == nil {
+		return helpers.Response(c, http.StatusNotFound, []string{"Category does not exist"})
+	}
+	if err != nil {
+		return helpers.Response(c, http.StatusInternalServerError, []string{err.Error()})
+	}
+
+	newProduct, err := ctrl.Options.UseCases.Product.CreateProduct(&req)
+	if err != nil {
+		return helpers.Response(c, http.StatusInternalServerError, []string{err.Error()})
+	}
+	return helpers.StandardResponse(c, http.StatusCreated, []string{"Product created successfully"}, newProduct, nil)
+}
+
+func (ctrl *productController) GetAllProduct(c echo.Context) error {
+	page, _ := strconv.Atoi(c.QueryParam("page"))
+	pageSize, _ := strconv.Atoi(c.QueryParam("page_size"))
+	if pageSize <= 0 {
+		pageSize = 10
+	}
+	categoryID, _ := strconv.Atoi(c.QueryParam("category_id"))
+
+	q := c.QueryParam("q")
+	includeDeleted := false
+	if c.QueryParam("include_deleted") == "true" {
+		includeDeleted = true
+	}
+	sortBy := c.QueryParam("sort_by")
+	sortOrder := c.QueryParam("sort_order")
+
+	mapParams := map[string]any{
+		"page":            page,
+		"page_size":       pageSize,
+		"category_id":     categoryID,
+		"q":               q,
+		"include_deleted": includeDeleted,
+		"sort_by":         sortBy,
+		"sort_order":      sortOrder,
+	}
+
+	schema := validet.NewSchema(
+		mapParams,
+		map[string]validet.Rule{
+			"page": validet.Numeric[int]{Required: false, Custom: func(v int, path validet.PathKey, lookup validet.Lookup) error {
+				if v != 0 && v < 1 {
+					return customerror.NewBadRequestError("page must be minimum of 1")
+				}
+				return nil
+			}},
+			"page_size": validet.Numeric[int]{Required: false, Custom: func(v int, path validet.PathKey, lookup validet.Lookup) error {
+				if v != 0 && v < 1 {
+					return customerror.NewBadRequestError("page_size must be minimum of 1 or maximum 100")
+				}
+				return nil
+			}},
+			"category_id": validet.Numeric[int]{Required: false, Custom: func(v int, path validet.PathKey, lookup validet.Lookup) error {
+				if v != 0 && v < 1 {
+					return customerror.NewBadRequestError("category_id must be minimum of 1")
+				}
+				return nil
+			}},
+			"q":               validet.String{Required: false, Max: 100},
+			"include_deleted": validet.Boolean{Required: false},
+			"sort_by": validet.String{Required: false, Max: 50, Custom: func(v string, path validet.PathKey, lookup validet.Lookup) error {
+				if v != "" && v != "id" && v != "name" && v != "price" && v != "stock" && v != "category_id" && v != "created_at" && v != "updated_at" {
+					return customerror.NewBadRequestError("Invalid sort by field")
+				}
+				return nil
+			}},
+			"sort_order": validet.String{Required: false, Max: 10, Custom: func(v string, path validet.PathKey, lookup validet.Lookup) error {
+				if v != "" && v != "asc" && v != "desc" {
+					return customerror.NewBadRequestError("Invalid sort order, must be 'asc' or 'desc")
+				}
+				return nil
+			}},
+		},
+		validet.Options{},
+	)
+
+	errorBags, err := schema.Validate()
+	if err != nil {
+		return helpers.StandardResponse(c, http.StatusBadRequest, errorBags.Errors, nil, nil)
+	}
+
+	product, total, err := ctrl.Options.UseCases.Product.GetAllProduct(page, pageSize, q, categoryID, includeDeleted, sortBy, sortOrder)
+	if err != nil {
+		return helpers.Response(c, http.StatusInternalServerError, []string{err.Error()})
+	}
+
+	if len(*product) == 0 {
+		return helpers.Response(c, http.StatusNotFound, []string{"No product found"})
+	}
+
+	return helpers.StandardResponse(c, http.StatusOK, []string{"Product fetched successfully"}, map[string]interface{}{
+		"total":   total,
+		"product": product,
+	}, nil)
+}
+
+func (ctrl *productController) UpdateProduct(c echo.Context) error {
+	id, _ := strconv.Atoi(c.Param("id"))
+
+	var req models.Product
+
+	if err := c.Bind(&req); err != nil {
+		return helpers.Response(c, http.StatusBadRequest, []string{"Invalid update request"})
+	}
+	mapReq := map[string]any{}
+	if req.Name != "" {
+		mapReq["name"] = req.Name
+	}
+	if req.Description != nil {
+		mapReq["description"] = *req.Description
+	}
+	if req.Price != 0 {
+		mapReq["price"] = req.Price
+	}
+	if req.Stock != 0 {
+		mapReq["stock"] = req.Stock
+	}
+	if req.CategoryID != nil {
+		category, err := ctrl.Options.UseCases.Category.IsCategoryExist(*req.CategoryID)
+		if category == nil {
+			return helpers.Response(c, http.StatusNotFound, []string{"Category does not exist"})
+		}
+		if err != nil {
+			return helpers.Response(c, http.StatusInternalServerError, []string{err.Error()})
+		}
+		mapReq["category_id"] = *req.CategoryID
+	}
+
+	if req.ImageURL != nil {
+		mapReq["image_url"] = *req.ImageURL
+	}
+
+	if len(mapReq) == 0 {
+		return helpers.Response(c, http.StatusBadRequest, []string{"No fields to update"})
+	}
+	schema := validet.NewSchema(
+		mapReq,
+		map[string]validet.Rule{
+			"name":        validet.String{Required: false, Max: 100},
+			"description": validet.String{Required: false, Max: 500},
+			"price": validet.Numeric[float64]{Required: false, Custom: func(v float64, path validet.PathKey, lookup validet.Lookup) error {
+				if v != 0 && v < 1 {
+					return customerror.NewBadRequestError("price must be minimum of 1")
+				}
+				return nil
+			}},
+			"stock": validet.Numeric[int]{Required: false, Custom: func(v int, path validet.PathKey, lookup validet.Lookup) error {
+				if v != 0 && v < 1 {
+					return customerror.NewBadRequestError("stock must be minimum of 1")
+				}
+				return nil
+			}},
+			"category_id": validet.Numeric[int]{Required: false, Custom: func(v int, path validet.PathKey, lookup validet.Lookup) error {
+				if v != 0 && v < 1 {
+					return customerror.NewBadRequestError("category_id must be minimum of 1")
+				}
+				return nil
+			}},
+			"image_url": validet.String{Required: false, Max: 255},
+		},
+		validet.Options{},
+	)
+	errorBags, err := schema.Validate()
+	if err != nil {
+		return helpers.StandardResponse(c, http.StatusBadRequest, errorBags.Errors, nil, nil)
+	}
+
+	product, err := ctrl.Options.UseCases.Product.UpdateProduct(id, mapReq)
+
+	if err != nil {
+		return helpers.Response(c, http.StatusInternalServerError, []string{err.Error()})
+	}
+	return helpers.StandardResponse(c, http.StatusOK, []string{"Product updated successfully"}, product, nil)
+}
+
+func (ctrl *productController) SoftDeleteProduct(c echo.Context) error {
+	id, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		return helpers.Response(c, http.StatusBadRequest, []string{"Invalid or empty product ID"})
+	}
+
+	mapReq := make(map[string]any)
+	if id != 0 && id > 0 {
+		mapReq["id"] = id
+	}
+
+	if len(mapReq) == 0 {
+		return helpers.Response(c, http.StatusBadRequest, []string{"Product ID is required"})
+	}
+
+	schema := validet.NewSchema(
+		mapReq,
+		map[string]validet.Rule{
+			"id": validet.Numeric[int]{Required: true, Custom: func(v int,
+				path validet.PathKey, lookup validet.Lookup) error {
+				if v != 0 && v < 1 {
+					return customerror.NewBadRequestError("Product ID must be greater than 0")
+				}
+				return nil
+			}},
+		},
+		validet.Options{},
+	)
+
+	errorBags, err := schema.Validate()
+	if err != nil {
+		return helpers.StandardResponse(c, http.StatusBadRequest, errorBags.Errors, nil, nil)
+	}
+
+	if err := ctrl.Options.UseCases.Product.SoftDeleteProduct(id); err != nil {
+		return helpers.Response(c, http.StatusInternalServerError, []string{err.Error()})
+	}
+	return helpers.StandardResponse(c, http.StatusOK, []string{"Product deleted successfully"}, nil, nil)
 }

--- a/app/models/category.go
+++ b/app/models/category.go
@@ -16,6 +16,48 @@ type Category struct {
 	Products []Product `json:"products,omitempty" gorm:"foreignKey:CategoryID"`
 }
 
+type CategoryAdmin struct {
+	ID             int        `json:"id" gorm:"primaryKey;autoIncrement"`
+	Name           string     `json:"name" gorm:"not null"`
+	Description    *string    `json:"description,omitempty"`
+	CreatedAt      time.Time  `json:"created_at" gorm:"autoCreateTime"`
+	UpdatedAt      time.Time  `json:"updated_at" gorm:"autoUpdateTime"`
+	DeletedAt      *time.Time `json:"deleted_at,omitempty" gorm:"index"`
+	IncludeRelated bool       `json:"include_related,omitempty" gorm:"index"`
+	IncludeDeleted bool       `json:"include_deleted,omitempty" gorm:"index"`
+	// Relationships
+	Products []Product `json:"products,omitempty" gorm:"foreignKey:CategoryID"`
+}
+
+type CategoryResponses struct {
+	ID          int       `json:"id"`
+	Name        string    `json:"name"`
+	Description *string   `json:"description`
+	CreatedAt   time.Time `json:"created_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
+
+	// Relationships
+	Products []Product `json:"products, omitempty"`
+}
+
+type CategoryInfo struct {
+	ID          int     `json:"id"`
+	Name        string  `json:"name"`
+	Description *string `json:"description`
+}
+
+// DTO
+func (c *Category) ToCategoryResponse(r []Product) CategoryResponses {
+	return CategoryResponses{
+		ID:          c.ID,
+		Name:        c.Name,
+		Description: c.Description,
+		CreatedAt:   c.CreatedAt,
+		UpdatedAt:   c.UpdatedAt,
+		Products:    r,
+	}
+}
+
 func (Category) TableName() string {
 	return "categories"
 }

--- a/app/models/product.go
+++ b/app/models/product.go
@@ -22,6 +22,24 @@ type Product struct {
 	OrderItems []OrderItem `json:"order_items,omitempty" gorm:"foreignKey:ProductID"`
 }
 
+type ProductAdmin struct {
+	ID             int        `json:"id" gorm:"primaryKey;autoIncrement"`
+	Name           string     `json:"name" gorm:"not null"`
+	Description    *string    `json:"description,omitempty"`
+	Price          float64    `json:"price" gorm:"type:decimal(12,2);not null"`
+	Stock          int        `json:"stock" gorm:"default:0"`
+	CategoryID     *int       `json:"category_id,omitempty"`
+	ImageURL       *string    `json:"image_url,omitempty"`
+	CreatedAt      time.Time  `json:"created_at" gorm:"autoCreateTime"`
+	UpdatedAt      time.Time  `json:"updated_at" gorm:"autoUpdateTime"`
+	DeletedAt      *time.Time `json:"deleted_at,omitempty" gorm:"index"`
+	IncludeDeleted bool       `json:"included_deleted,omitempty" gorm:"index"`
+	// Relationships
+	Category   *Category   `json:"category,omitempty" gorm:"foreignKey:CategoryID;references:ID"`
+	CartItems  []CartItem  `json:"cart_items,omitempty" gorm:"foreignKey:ProductID"`
+	OrderItems []OrderItem `json:"order_items,omitempty" gorm:"foreignKey:ProductID"`
+}
+
 // DTO
 type ProductResponse struct {
 	ID           int               `json:"id"`
@@ -45,6 +63,22 @@ type ProductRelated struct {
 	ImageURL *string `json:"image_url,omitempty"`
 }
 
+type ProductCategory struct {
+	ID          int        `json:"id"`
+	Name        string     `json:"name`
+	Description *string    `json:"description,omitempty"`
+	Price       float64    `json:"price" `
+	Stock       int        `json:"stock"`
+	CategoryID  *int       `json:"category_id,omitempty"`
+	ImageURL    *string    `json:"image_url,omitempty"`
+	CreatedAt   time.Time  `json:"created_at" `
+	UpdatedAt   time.Time  `json:"updated_at"`
+	DeletedAt   *time.Time `json:"deleted_at,omitempty"`
+
+	// Relationships
+	CategoryInfo CategoryResponse `json:"category_info,omitempty" gorm:"foreignKey:CategoryID;references:ID"`
+}
+
 // DTO
 func (p *Product) ToProductResponse(r []ProductRelated) ProductResponse {
 	return ProductResponse{
@@ -61,6 +95,23 @@ func (p *Product) ToProductResponse(r []ProductRelated) ProductResponse {
 			Name: p.Category.Name,
 		},
 		Related: r,
+	}
+}
+
+func ToProductCategory(p Product) ProductCategory {
+	return ProductCategory{
+		ID:          p.ID,
+		Name:        p.Name,
+		Description: p.Description,
+		Price:       p.Price,
+		Stock:       p.Stock,
+		ImageURL:    p.ImageURL,
+		CreatedAt:   p.CreatedAt,
+		UpdatedAt:   p.UpdatedAt,
+		CategoryInfo: CategoryResponse{
+			ID:   p.Category.ID,
+			Name: p.Category.Name,
+		},
 	}
 }
 

--- a/app/models/user_dto.go
+++ b/app/models/user_dto.go
@@ -101,8 +101,10 @@ type UpdateUserRequest struct {
 }
 
 // RegisterRequest represents the request for registering a new shopper
+/*
 type RegisterRequest struct {
 	Name     string `json:"name" validate:"required"`
 	Email    string `json:"email" validate:"required,email"`
 	Password string `json:"password" validate:"required,min=6"`
 }
+*/

--- a/app/repositories/category_repository.go
+++ b/app/repositories/category_repository.go
@@ -1,0 +1,154 @@
+package repositories
+
+import (
+	"errors"
+	"monitoring-service/app/models"
+	"time"
+)
+
+type categoryRepository repository
+
+type CategoryRepositoryInterface interface {
+	GetCategoryByID(categoryID int, include_related bool) (*models.Category, []models.Product, error)
+	//GetAllCategory(included_deleted bool) (*[]models.Category, error)
+	GetAllCategory(page, pageSize int, q string, included_deleted bool) (*[]models.Category, int64, error)
+	CreateCategory(category *models.Category) (*models.Category, error)
+	UpdateCategory(categoryID int, updates map[string]interface{}) (*models.Category, error)
+	SoftDeleteCategory(categoryID int) error
+	IsCategoryExist(categoryID int) (*models.Category, error)
+}
+
+func (r *categoryRepository) GetCategoryByID(categoryID int, include_related bool) (*models.Category, []models.Product, error) {
+	var category models.Category
+	var related []models.Product
+
+	if include_related {
+		err := r.Options.Postgres.
+			Preload("Products", "deleted_at IS NULL").
+			First(&category, "id = ? AND deleted_at IS NULL", categoryID).Error
+		if err != nil {
+			return nil, nil, err
+		}
+		related = category.Products
+	} else {
+		err := r.Options.Postgres.
+			First(&category, "id = ? AND deleted_at IS NULL", categoryID).Error
+		if err != nil {
+			return nil, nil, err
+		}
+		related = nil
+	}
+
+	return &category, related, nil
+}
+
+func (r *categoryRepository) GetAllCategory(page, pageSize int, q string, included_deleted bool) (*[]models.Category, int64, error) {
+	var allCategory []models.Category
+	var total int64
+
+	baseQuery := r.Options.Postgres.Model(&models.Category{})
+	if !included_deleted {
+		baseQuery = baseQuery.Where("deleted_at IS NULL")
+	} else {
+		baseQuery = baseQuery.Unscoped()
+	}
+
+	if q != "" {
+		baseQuery = baseQuery.Where("name ILIKE ?", "%"+q+"%")
+	}
+
+	// Count total items
+	if err := baseQuery.Count(&total).Error; err != nil {
+		return nil, 0, err
+	}
+
+	// Fetch paginated rows using a **new query** with same filters
+	query := r.Options.Postgres.Model(&models.Category{})
+	if !included_deleted {
+		query = query.Where("deleted_at IS NULL")
+	} else {
+		query = query.Unscoped()
+	}
+	if q != "" {
+		query = query.Where("name ILIKE ?", "%"+q+"%")
+	}
+
+	offset := (page - 1) * pageSize
+	if err := query.Limit(pageSize).Offset(offset).Find(&allCategory).Error; err != nil {
+		return nil, 0, err
+	}
+
+	return &allCategory, total, nil
+}
+
+func (r *categoryRepository) CreateCategory(category *models.Category) (*models.Category, error) {
+	err := r.Options.Postgres.Create(category).Error
+
+	if err != nil {
+		return nil, err
+	}
+	return category, nil
+}
+
+func (r *categoryRepository) UpdateCategory(categoryID int, updates map[string]interface{}) (*models.Category, error) {
+	var category models.Category
+	result := r.Options.Postgres.Model(&models.Category{}).
+		Where("id = ? AND deleted_at IS NULL", categoryID).
+		Updates(updates)
+
+	if result.Error != nil {
+		return nil, result.Error
+	}
+
+	if result.RowsAffected == 0 {
+		return nil, errors.New("Category not found")
+	}
+
+	err := r.Options.Postgres.First(&category, categoryID).Error
+	if err != nil {
+		return nil, err
+	}
+
+	return &category, nil
+}
+
+func (r *categoryRepository) SoftDeleteCategory(categoryID int) error {
+	var count int64
+
+	err := r.Options.Postgres.Model(&models.Product{}).
+		Where("category_id = ? AND deleted_at IS NULL", categoryID).
+		Count(&count).Error
+
+	if err != nil {
+		return err
+	}
+
+	if count > 0 {
+		return errors.New("cannot delete category: there are active products referencing it")
+	}
+
+	result := r.Options.Postgres.Model(&models.Category{}).
+		Where("id = ? AND deleted_at IS NULL", categoryID).
+		Update("deleted_at", time.Now())
+
+	if result.Error != nil {
+		return result.Error
+	}
+
+	if result.RowsAffected == 0 {
+		return errors.New("Category didn't found or already deleted")
+	}
+	return nil
+}
+
+func (r *categoryRepository) IsCategoryExist(categoryID int) (*models.Category, error) {
+	var category models.Category
+
+	err := r.Options.Postgres.
+		First(&category, "id = ? AND deleted_at IS NULL", categoryID).Error
+	if err != nil {
+		return nil, err
+	}
+
+	return &category, nil
+}

--- a/app/repositories/init.go
+++ b/app/repositories/init.go
@@ -10,6 +10,7 @@ type Main struct {
 	User     UserRepositoryInterface
 	UserRole UserRolesRepositoryInterface
 	Product  ProductRepositoryInterface
+	Category CategoryRepositoryInterface
 }
 
 type repository struct {
@@ -28,6 +29,7 @@ func Init(opts Options) *Main {
 		User:     (*userRepository)(repo),
 		UserRole: (*userRolesRepository)(repo),
 		Product:  (*productRepository)(repo),
+		Category: (*categoryRepository)(repo),
 	}
 
 	return m

--- a/app/repositories/product_repository.go
+++ b/app/repositories/product_repository.go
@@ -1,13 +1,20 @@
 package repositories
 
 import (
+	"errors"
 	"monitoring-service/app/models"
+	"time"
 )
 
 type productRepository repository
 
 type ProductRepositoryInterface interface {
 	GetProductByID(productID int) (*models.Product, []models.ProductRelated, error)
+	CreateProduct(product *models.Product) (*models.Product, error)
+	UpdateProduct(productID int, updates map[string]interface{}) (*models.Product, error)
+	SoftDeleteProduct(productID int) error
+	//GetAllProduct(included_deleted bool) (*[]models.Product, error)
+	GetAllProduct(page, pageSize int, q string, categoryID int, included_deleted bool, sortBy string, sortOrder string) (*[]models.Product, int64, error)
 }
 
 func (r *productRepository) GetProductByID(productID int) (*models.Product, []models.ProductRelated, error) {
@@ -33,4 +40,103 @@ func (r *productRepository) GetProductByID(productID int) (*models.Product, []mo
 	}
 
 	return &product, related, nil
+}
+
+func (r *productRepository) CreateProduct(product *models.Product) (*models.Product, error) {
+	err := r.Options.Postgres.Create(product).Error
+
+	if err != nil {
+		return nil, err
+	}
+	return product, nil
+}
+
+func (r *productRepository) GetAllProduct(page, pageSize int, q string, categoryID int, included_deleted bool, sortBy string, sortOrder string) (*[]models.Product, int64, error) {
+	var allProduct []models.Product
+	var total int64
+
+	baseQuery := r.Options.Postgres.Model(&models.Product{})
+	if !included_deleted {
+		baseQuery = baseQuery.Where("deleted_at IS NULL")
+	} else {
+		baseQuery = baseQuery.Unscoped()
+	}
+
+	if q != "" {
+		baseQuery = baseQuery.Where("name ILIKE ?", "%"+q+"%")
+	}
+
+	if categoryID > 0 {
+		baseQuery = baseQuery.Where("category_id = ?", categoryID)
+	}
+
+	// Count total items
+	if err := baseQuery.Count(&total).Error; err != nil {
+		return nil, 0, err
+	}
+
+	// Fetch paginated rows using a **new query** with same filters
+	query := r.Options.Postgres.Model(&models.Product{}).Preload("Category")
+	if !included_deleted {
+		query = query.Where("deleted_at IS NULL")
+	} else {
+		query = query.Unscoped()
+	}
+	if q != "" {
+		query = query.Where("name ILIKE ?", "%"+q+"%")
+	}
+	if categoryID > 0 {
+		query = query.Where("category_id = ?", categoryID)
+	}
+	if sortBy != "" {
+		order := "asc"
+		if sortOrder != "" {
+			order = sortOrder
+		}
+		query = query.Order(sortBy + " " + order)
+	}
+
+	offset := (page - 1) * pageSize
+	if err := query.Limit(pageSize).Offset(offset).Find(&allProduct).Error; err != nil {
+		return nil, 0, err
+	}
+
+	return &allProduct, total, nil
+}
+
+func (r *productRepository) UpdateProduct(productID int, updates map[string]interface{}) (*models.Product, error) {
+	var product models.Product
+	result := r.Options.Postgres.Model(&models.Product{}).
+		Where("id = ? AND deleted_at IS NULL", productID).
+		Updates(updates)
+
+	if result.Error != nil {
+		return nil, result.Error
+	}
+
+	if result.RowsAffected == 0 {
+		return nil, errors.New("Product not found")
+	}
+
+	err := r.Options.Postgres.First(&product, productID).Error
+	if err != nil {
+		return nil, err
+	}
+
+	return &product, nil
+}
+
+func (r *productRepository) SoftDeleteProduct(productID int) error {
+	result := r.Options.Postgres.Model(&models.Product{}).
+		Where("id = ? AND deleted_at IS NULL", productID).
+		Update("deleted_at", time.Now())
+
+	if result.Error != nil {
+		return result.Error
+	}
+
+	if result.RowsAffected == 0 {
+		return errors.New("Product didn't found or already deleted")
+	}
+	return nil
 }

--- a/app/repositories/user_repository.go
+++ b/app/repositories/user_repository.go
@@ -14,7 +14,7 @@ type UserRepositoryInterface interface {
 	GetAllUsers(limit, offset int) ([]models.User, int64, error)
 	GetUserByID(id int) (*models.User, error)
 	EmailExists(email string) (bool, error)
-	CreateUser(user models.User) (*models.User, error)
+	CreateUser(user *models.User) (*models.User, error)
 	GetRoleByName(name string) (*models.Role, error)
 	AssignRole(userRole models.UserRole) error
 	GetUserByEmail(email string) (*models.User, error)
@@ -65,9 +65,9 @@ func (r *userRepository) EmailExists(email string) (bool, error) {
 	return count > 0, err
 }
 
-func (r *userRepository) CreateUser(user models.User) (*models.User, error) {
-	err := r.Options.Postgres.Create(&user).Error
-	return &user, err
+func (r *userRepository) CreateUser(user *models.User) (*models.User, error) {
+	err := r.Options.Postgres.Create(user).Error
+	return user, err
 }
 
 func (r *userRepository) GetRoleByName(name string) (*models.Role, error) {

--- a/app/routes/routes.go
+++ b/app/routes/routes.go
@@ -24,6 +24,26 @@ func ConfigureRouter(e *echo.Echo, controller *controllers.Main) {
 	userGroup.GET("", controller.User.GetAllUsers)
 	userGroup.GET("/:id", controller.User.GetUserByID)
 
+	// Product routes
 	productGroup := v1.Group("/product")
 	productGroup.GET("/:id", controller.Product.GetProductByID)
+
+	// Admin routes for product management
+	adminProductGroup := productGroup.Group("", controller.Auth.IsAdminJWT)
+	adminProductGroup.POST("", controller.Product.CreateProduct)
+	adminProductGroup.GET("", controller.Product.GetAllProduct)
+	adminProductGroup.PUT("/:id", controller.Product.UpdateProduct)
+	adminProductGroup.DELETE("/:id", controller.Product.SoftDeleteProduct)
+
+	// Category routes
+	categoryGroup := v1.Group("/categories")
+	categoryGroup.GET("/:id", controller.Category.GetCategoryByID)
+
+	// Admin routes for category management
+	adminCategoryGroup := categoryGroup.Group("", controller.Auth.IsAdminJWT)
+	adminCategoryGroup.GET("", controller.Category.GetAllCategory)
+	adminCategoryGroup.POST("", controller.Category.CreateCategory)
+	adminCategoryGroup.PUT("/:id", controller.Category.UpdateCategory)
+	adminCategoryGroup.DELETE("/:id", controller.Category.SoftDeleteCategory)
+
 }

--- a/app/usecases/category_usecase.go
+++ b/app/usecases/category_usecase.go
@@ -1,0 +1,87 @@
+package usecases
+
+import (
+	"monitoring-service/app/models"
+)
+
+type categoryUsecase usecase
+
+type CategoryUsecaseInterface interface {
+	GetCategoryByID(id int, include_related bool) (*models.CategoryResponses, error)
+	//GetAllCategory(included_deleted bool) (*[]models.Category, error)
+	GetAllCategory(page, pageSize int, q string, included_deleted bool) (*[]models.Category, int64, error)
+	CreateCategory(category *models.Category) (*models.Category, error)
+	UpdateCategory(id int, updates map[string]interface{}) (*models.Category, error)
+	SoftDeleteCategory(id int) error
+	IsCategoryExist(categoryID int) (*models.Category, error)
+}
+
+func (u *categoryUsecase) GetCategoryByID(id int, include_related bool) (*models.CategoryResponses, error) {
+	category, related, err := u.Options.Repository.Category.GetCategoryByID(id, include_related)
+
+	if err != nil {
+		return nil, err
+	}
+
+	response := category.ToCategoryResponse(related)
+	return &response, nil
+}
+
+/*
+func (u *categoryUsecase) GetAllCategory(included_deleted bool) (*[]models.Category, error) {
+	allCategory, err := u.Options.Repository.Category.GetAllCategory(included_deleted)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return allCategory, nil
+}
+
+*/
+
+func (u *categoryUsecase) GetAllCategory(page, pageSize int, q string, included_deleted bool) (*[]models.Category, int64, error) {
+	allCategory, total, err := u.Options.Repository.Category.GetAllCategory(page, pageSize, q, included_deleted)
+
+	if err != nil {
+		return nil, 0, err
+	}
+
+	return allCategory, total, nil
+}
+
+func (u *categoryUsecase) CreateCategory(category *models.Category) (*models.Category, error) {
+	newCategory, err := u.Options.Repository.Category.CreateCategory(category)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return newCategory, nil
+}
+
+func (u *categoryUsecase) UpdateCategory(id int, updates map[string]interface{}) (*models.Category, error) {
+	category, err := u.Options.Repository.Category.UpdateCategory(id, updates)
+	if err != nil {
+		return nil, err
+	}
+
+	return category, nil
+}
+
+func (u *categoryUsecase) SoftDeleteCategory(id int) error {
+	return u.Options.Repository.Category.SoftDeleteCategory(id)
+}
+
+func (u *categoryUsecase) IsCategoryExist(categoryID int) (*models.Category, error) {
+	category, err := u.Options.Repository.Category.IsCategoryExist(categoryID)
+	if err != nil {
+		return nil, err
+	}
+
+	if category == nil {
+		return nil, nil
+	}
+
+	return category, nil
+}

--- a/app/usecases/init.go
+++ b/app/usecases/init.go
@@ -6,9 +6,10 @@ import (
 )
 
 type Main struct {
-	User    UserUsecaseInterface
-	Auth    AuthUsecaseInterface
-	Product productUsecaseInterface
+	User     UserUsecaseInterface
+	Auth     AuthUsecaseInterface
+	Product  productUsecaseInterface
+	Category CategoryUsecaseInterface
 }
 
 type usecase struct {
@@ -24,9 +25,10 @@ func Init(opts Options) *Main {
 	ucs := &usecase{opts}
 
 	m := &Main{
-		User:    (*userUsecase)(ucs),
-		Auth:    (*authUsecase)(ucs),
-		Product: (*productUsecase)(ucs),
+		User:     (*userUsecase)(ucs),
+		Auth:     (*authUsecase)(ucs),
+		Product:  (*productUsecase)(ucs),
+		Category: (*categoryUsecase)(ucs),
 	}
 
 	return m

--- a/app/usecases/product_usecase.go
+++ b/app/usecases/product_usecase.go
@@ -8,6 +8,11 @@ type productUsecase usecase
 
 type productUsecaseInterface interface {
 	GetProductByID(id int) (*models.ProductResponse, error)
+	CreateProduct(product *models.Product) (*models.Product, error)
+	UpdateProduct(id int, updates map[string]interface{}) (*models.Product, error)
+	SoftDeleteProduct(id int) error
+	//GetAllProduct(included_deleted bool) (*[]models.Product, error)
+	GetAllProduct(page, pageSize int, q string, categoryID int, included_deleted bool, sortBy string, sortOrder string) (*[]models.Product, int64, error)
 }
 
 func (u *productUsecase) GetProductByID(id int) (*models.ProductResponse, error) {
@@ -18,4 +23,37 @@ func (u *productUsecase) GetProductByID(id int) (*models.ProductResponse, error)
 
 	response := product.ToProductResponse(related)
 	return &response, nil
+}
+
+func (u *productUsecase) CreateProduct(product *models.Product) (*models.Product, error) {
+	newProduct, err := u.Options.Repository.Product.CreateProduct(product)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return newProduct, nil
+}
+
+func (u *productUsecase) GetAllProduct(page, pageSize int, q string, categoryID int, included_deleted bool, sortBy string, sortOrder string) (*[]models.Product, int64, error) {
+	allProduct, total, err := u.Options.Repository.Product.GetAllProduct(page, pageSize, q, categoryID, included_deleted, sortBy, sortOrder)
+
+	if err != nil {
+		return nil, 0, err
+	}
+
+	return allProduct, total, nil
+}
+
+func (u *productUsecase) UpdateProduct(id int, updates map[string]interface{}) (*models.Product, error) {
+	product, err := u.Options.Repository.Product.UpdateProduct(id, updates)
+	if err != nil {
+		return nil, err
+	}
+
+	return product, nil
+}
+
+func (u *productUsecase) SoftDeleteProduct(id int) error {
+	return u.Options.Repository.Product.SoftDeleteProduct(id)
 }

--- a/app/usecases/user_usecase.go
+++ b/app/usecases/user_usecase.go
@@ -86,7 +86,7 @@ func (u *userUsecase) Register(request models.RegisterRequest) (string, error) {
 		Password: string(hashedPassword),
 	}
 
-	newUser, err := u.Options.Repository.User.CreateUser(user)
+	newUser, err := u.Options.Repository.User.CreateUser(&user)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
## Summary
Create CRUD for products and categories for Admin only

## Changes
- Add and change CRUD for category
- Add and change CRUD for product
- Add validation input in category and product controller
- For product, add pagination, search by name, filter product by category id, sort, and include category info in get product detail
- For category, add pagination and search by name
- Add include_deleted=true for admin
- Change routes for CRUD product and category as admin only (JWT with role=admin)

## Testing
- Tested with multiple categories.
- Confirmed only admin can access the CRUD endpoint for product and category
- Confirmed list of product and category support pagination, search, filter by category, and sort
- Confirmed admin can include deleted category or product if needed
- Confirmed admin can include category info in product list if needed
- Verified return consisten error payloads (validation 400, not found 404, conflict 409, and unauthorized 401/403)
